### PR TITLE
Fix: incorrect double format for workshop numbers.

### DIFF
--- a/Deltinteger/Deltinteger/Elements/Values.cs
+++ b/Deltinteger/Deltinteger/Elements/Values.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -524,7 +525,7 @@ namespace Deltin.Deltinteger.Elements
 
         public override string ToWorkshop()
         {
-            return value.ToString();
+            return value.ToString(CultureInfo.InvariantCulture);
         }
 
         public override void DebugPrint(Log log, int depth = 0)


### PR DESCRIPTION
Fix only double format incorrect in #32

Script:
```
rule: "Test"
{
	foreach(define player in AllPlayers())
		SmallMessage(player, <"Current objective: Survive">);
}
```

Output:
```
// --- Variable Guide ---
// global A[0] INTERNAL : ContinueSkip
// global A[1] INTERNAL : 'player' for index
// element reference : player

rule("Test")
{

	event
	{
		Ongoing - Global;
	}
	
	// Action count: 9
	actions
	{
		Wait(0,016, Ignore Condition); // ContinueSkip Wait
		Skip If(Compare(Value In Array(Global Variable(A), 0), !=, 0), Value In Array(Global Variable(A), 0)); // ContinueSkip Skipper
		Set Global Variable At Index(A, 1, 0);
		Skip If(Not(Compare(Value In Array(Global Variable(A), 1), <, Count Of(All Players(Team(All))))), 4);
		Small Message(Value In Array(All Players(Team(All)), Value In Array(Global Variable(A), 1)), String("{0} {1} {2}", String("current", Null, Null, Null), String("{0}:", String("objective", Null, Null, Null), Null, Null), String("survive", Null, Null, Null)));
		Set Global Variable At Index(A, 1, Add(Value In Array(Global Variable(A), 1), 1));
		Set Global Variable At Index(A, 0, 1);
		Loop;
		Set Global Variable At Index(A, 0, 0);
	}
}
```

correct format: `Wait(0.016, Ignore Condition);`