### PR TITLE
fix a typo 

### DIFF
--- a/Deltinteger/Deltinteger/Elements.json
+++ b/Deltinteger/Deltinteger/Elements.json
@@ -6825,7 +6825,7 @@
       "McCree Flashbang Stunned Effect",
       "Sombra Hacked Starting Effect",
       "Ana Biotic Grenade Increased Healing Sound",
-      "Ana Biotic Grenage No Healing Sound",
+      "Ana Biotic Grenade No Healing Sound",
       "Ana Sleeping Sound",
       "Reaper Wraith Form Sound",
       "Sombra Translocating Sound",


### PR DESCRIPTION
I was going to report an issue for this. But I found out what the problem was, and after modifying and compiling it, it worked fine for me, so I created this PR, hope you don't mind.

OSTW code:
```c#
rule: 'My Rule'
if (IsButtonHeld(HostPlayer(), Button.Interact))
{
	PlayEffect(AllPlayers(), PlayEffect.AnaBioticGrenageNoHealingSound, Color.Team1, Vector(0, 0, 0), 200);
}
```
Workshop script:
```
variables
{
    global:
        0: _extendedGlobalCollection
        1: _arrayBuilder
    player:
        0: _extendedPlayerCollection
}

// Extended collection variables:
// global [0]: _arrayBuilderStore

// Class identifiers:

rule("My Rule")
{

    event
    {
        Ongoing - Global;
    }

    conditions
    {
        Is Button Held(Host Player, Button(Interact)) == True;
    }

    // Action count: 1
    actions
    {
        Play Effect(All Players(Team(All)), Ana Biotic Grenage No Healing Sound, Color(Team 1), Subtract(Left, Left), 200);
    }
}
```
Error when paste this in game:
![1](https://user-images.githubusercontent.com/74082054/110695608-1012cb00-8225-11eb-9c58-96270ed1c4ea.png)


