### PR TITLE
fix: Update lobby settings validation JSON for Mei

### DIFF
--- a/overwatch-script-to-workshop/json-schemas/LobbySettingValidation.json
+++ b/overwatch-script-to-workshop/json-schemas/LobbySettingValidation.json
@@ -1625,7 +1625,6 @@
     "Weapon Freeze Rate Scalar": {
       "default": 100.0,
       "type": "number",
-      "minimum": 25.0,
       "maximum": 500.0
     },
     "Ultimate Ability (Valkyrie)": {


### PR DESCRIPTION
While Mei's freeze rate scalar was properly allowed to be 0 to 500 on the language server, the validation schema was not updated in the extension. This pull request updates the JSON file to properly reflect the change in schema.