### PR TITLE
fix: Make class static attributes compile to global Workshop variables

### DIFF
--- a/Deltinteger/Deltinteger/Parse/Variables/IStaticVariableCollection.cs
+++ b/Deltinteger/Deltinteger/Parse/Variables/IStaticVariableCollection.cs
@@ -7,6 +7,7 @@ namespace Deltin.Deltinteger.Parse
     {
         public IEnumerable<StaticVariable> StaticVariables => _staticVariables;
         readonly List<StaticVariable> _staticVariables = new List<StaticVariable>();
+        private readonly GetVariablesAssigner defaultStaticAssigner = new GetVariablesAssigner(null as InstanceAnonymousTypeLinker);
 
         // Static variable with known value
         public void AddVariable(IVariable variable, IWorkshopTree value) =>
@@ -15,7 +16,7 @@ namespace Deltin.Deltinteger.Parse
         // User-defined static variable
         public void AddVariable(IVariable variable) =>
             _staticVariables.Add(new StaticVariable(variable, actionSet => actionSet.DeltinScript.DefaultIndexAssigner.Add(variable,
-                variable.GetDefaultInstance(null).GetAssigner().GetValue(
+                variable.GetDefaultInstance(null).GetAssigner(defaultStaticAssigner).GetValue(
                     new GettableAssignerValueInfo(actionSet)))));
 
         public void Init(DeltinScript deltinScript) { }


### PR DESCRIPTION
Previously, they were incorrectly initialized as player variables in the `Initial Global` rule, resulting in an error.

Example:
```cs
class Example {
    public static Number n1 = 1;

    public constructor() {
        n1++;
    }
}

playervar Example myExample;

rule: "test"
Event.OngoingPlayer
{
    myExample = new Example();
}
```

Previous output:
```haskell
variables
{
    global:
        0: _classIndexes
    player:
        0: n1
        1: myExample
        2: _extendedPlayerCollection
}

// Extended collection variables:
// player [0]: _new_Example_class_index

rule("Initial Global")
{

    event
    {
        Ongoing - Global;
    }

    // Action count: 2
    actions
    {
        Set Player Variable(Event Player, n1, 1); // !! THIS IS INVALID !!
        Set Global Variable At Index(_classIndexes, 0, -1);
    }
}

rule("test")
{

    event
    {
        Ongoing - Each Player;
        All;
        All;
    }

    // Action count: 5
    actions
    {
        Set Player Variable At Index(Event Player, _extendedPlayerCollection, 0, Index Of Array Value(Global Variable(_classIndexes), 0));
        Set Player Variable At Index(Event Player, _extendedPlayerCollection, 0, If-Then-Else(Compare(First Of(Player Variable(Event Player, _extendedPlayerCollection)), ==, -1), Count Of(Global Variable(_classIndexes)), First Of(Player Variable(Event Player, _extendedPlayerCollection))));
        Set Global Variable At Index(_classIndexes, First Of(Player Variable(Event Player, _extendedPlayerCollection)), 1);
        Modify Player Variable(Event Player, n1, Add, 1);
        Set Player Variable(Event Player, myExample, First Of(Player Variable(Event Player, _extendedPlayerCollection)));
    }
}
```

New output:
```haskell
variables
{
    global:
        0: n1
        1: _classIndexes
    player:
        0: myExample
        1: _extendedPlayerCollection
}

// Extended collection variables:
// player [0]: _new_Example_class_index

rule("Initial Global")
{

    event
    {
        Ongoing - Global;
    }

    // Action count: 2
    actions
    {
        Set Global Variable(n1, 1);
        Set Global Variable At Index(_classIndexes, 0, -1);
    }
}

rule("test")
{

    event
    {
        Ongoing - Each Player;
        All;
        All;
    }

    // Action count: 5
    actions
    {
        Set Player Variable At Index(Event Player, _extendedPlayerCollection, 0, Index Of Array Value(Global Variable(_classIndexes), 0));
        Set Player Variable At Index(Event Player, _extendedPlayerCollection, 0, If-Then-Else(Compare(First Of(Player Variable(Event Player, _extendedPlayerCollection)), ==, -1), Count Of(Global Variable(_classIndexes)), First Of(Player Variable(Event Player, _extendedPlayerCollection))));
        Set Global Variable At Index(_classIndexes, First Of(Player Variable(Event Player, _extendedPlayerCollection)), 1);
        Modify Player Variable(n1, Add, 1);
        Set Player Variable(Event Player, myExample, First Of(Player Variable(Event Player, _extendedPlayerCollection)));
    }
}
```

