### PR TITLE
Add missing maps

### DIFF
--- a/Deltinteger/Deltinteger/Elements.json
+++ b/Deltinteger/Deltinteger/Elements.json
@@ -7040,6 +7040,7 @@
     "ThrottleRev": ["Direction And Magnitude", "None"],
     "Map": [
       "Ayutthaya",
+      "Antarctic Peninsula",
       {
         "name": "Black Forest",
         "alias": "Black_Forest"

--- a/Deltinteger/Deltinteger/Elements.json
+++ b/Deltinteger/Deltinteger/Elements.json
@@ -7040,7 +7040,10 @@
     "ThrottleRev": ["Direction And Magnitude", "None"],
     "Map": [
       "Ayutthaya",
-      "Antarctic Peninsula",
+      {
+        "name": "Antarctic Peninsula",
+        "alias": "Antarctic_Peninsula"
+      },
       {
         "name": "Black Forest",
         "alias": "Black_Forest"

--- a/Deltinteger/Deltinteger/Elements.json
+++ b/Deltinteger/Deltinteger/Elements.json
@@ -7223,6 +7223,10 @@
         "alias": "Route_66"
       },
       {
+        "name": "Shambali Monastery",
+        "alias": "Shambali_Monastery"
+      },
+      {
         "name": "Sydney Harbour Arena",
         "alias": "Sydney_Harbour_Arena"
       },

--- a/Deltinteger/Deltinteger/Lobby/Modes.cs
+++ b/Deltinteger/Deltinteger/Lobby/Modes.cs
@@ -325,7 +325,7 @@ namespace Deltin.Deltinteger.Lobby
                     .AddSelect("Flag Carrier Abilities", "Restricted", "All", "None").AddRange("Flag Dropped Lock Time", 0, 10, 5).AddRange("Flag Pickup Time", 0, 5, 0).AddRange("Flag Return Time", 0, 5, 4)
                     .AddRange("Flag Score Respawn Time", 0, 20, 15).AddIntRange("Game Length (Minutes)", false, 5, 15, 8).AddRange("Respawn Speed Buff Duration", 0, 60, 0).Add(ScoreToWin_1to9)
                     .AddSwitch("Team Needs Flag At Base To Score", false),
-                new ModeSettingCollection("Deathmatch", false).Add(GameLengthInMinutes).Add(SelfInitiatedRespawn).AddIntRange("Score To Win", false, 1, 50, 20, "Score To Win 1-50"),
+                new ModeSettingCollection("Deathmatch", false).Add(GameLengthInMinutes).Add(SelfInitiatedRespawn).AddIntRange("Score To Win", false, 1, 5000, 20, "Score To Win 1-5000"),
                 new ModeSettingCollection("Elimination", false).Elimination(),
                 new ModeSettingCollection("Team Deathmatch", false).Add(GameLengthInMinutes).AddSwitch("Mercy Resurrect Counteracts Kills", true).AddIntRange("Score To Win", false, 1, 200, 30, "Score To Win 1-200").Add(SelfInitiatedRespawn).AddSwitch("Imbalanced Team Score To Win", false)
                     .AddIntRange("Team 1 Score To Win", false, 1, 200, 30).AddIntRange("Team 2 Score To Win", false, 1, 200, 30),

--- a/Deltinteger/Deltinteger/Maps.json
+++ b/Deltinteger/Deltinteger/Maps.json
@@ -671,5 +671,12 @@
       "Push",
       "Skirmish"
     ]
+  },
+  {
+    "Name": "Shambali Monastery",
+    "GameModes": [
+      "Escort",
+      "Skirmish"
+    ]
   }
 ]

--- a/Deltinteger/Deltinteger/Maps.json
+++ b/Deltinteger/Deltinteger/Maps.json
@@ -678,5 +678,12 @@
       "Escort",
       "Skirmish"
     ]
+  },
+  {
+    "Name": "Antarctic Peninsula",
+    "GameModes": [
+      "Control",
+      "Skirmish"
+    ]
   }
 ]


### PR DESCRIPTION
also fixes a warning if you set the deathmatch score to win above 50