### PR TITLE
Fix Issue #425: Restore void return type check

### DIFF
--- a/Deltinteger/Deltinteger/Parse/Functions/Builder/User/UserFunctionController.cs
+++ b/Deltinteger/Deltinteger/Parse/Functions/Builder/User/UserFunctionController.cs
@@ -57,7 +57,7 @@ namespace Deltin.Deltinteger.Parse.Functions.Builder.User
             IsMultiplePaths());
 
         bool IsMultiplePaths() => _function.Provider.ReturnType != null && (
-            _function.Provider.MultiplePaths || _function.Attributes.Recursive || _function.Provider.SubroutineName != null) || _function.Provider.Virtual;
+            _function.Provider.MultiplePaths || _function.Attributes.Recursive || _function.Provider.SubroutineName != null) || (_function.Provider.Virtual && _function.Provider.ReturnType.GetNameOrVoid() != "void");
 
         // Creates parameters assigned to this function.
         public IParameterHandler CreateParameterHandler(ActionSet actionSet, WorkshopParameter[] providedParameters)

--- a/Deltinteger/Deltinteger/Parse/Functions/Builder/User/UserFunctionController.cs
+++ b/Deltinteger/Deltinteger/Parse/Functions/Builder/User/UserFunctionController.cs
@@ -57,7 +57,7 @@ namespace Deltin.Deltinteger.Parse.Functions.Builder.User
             IsMultiplePaths());
 
         bool IsMultiplePaths() => _function.Provider.ReturnType != null && (
-            _function.Provider.MultiplePaths || _function.Attributes.Recursive || _function.Provider.SubroutineName != null) || (_function.Provider.Virtual && _function.Provider.ReturnType.GetNameOrVoid() != "void");
+            _function.Provider.MultiplePaths || _function.Attributes.Recursive || _function.Provider.SubroutineName != null || _function.Provider.Virtual);
 
         // Creates parameters assigned to this function.
         public IParameterHandler CreateParameterHandler(ActionSet actionSet, WorkshopParameter[] providedParameters)


### PR DESCRIPTION
This pull request addresses Issue #425 by restoring a check to ensure that methods with a return type of void do not make IsMultiplePaths true.