### PR TITLE
build: Bump .NET framework to match project target framework

### DIFF
--- a/Deltinteger/Deltinteger/publish.ps1
+++ b/Deltinteger/Deltinteger/publish.ps1
@@ -1,5 +1,5 @@
 $configuration = 'Release'
-$framework = 'netcoreapp3.0'
+$framework = 'net6.0'
 $ostw_version = 'v2.6'
 
 # Cross platform, no runtime included.


### PR DESCRIPTION
This pull request bumps the stated framework in the `publish.ps1` script to match the project's target framework.