### PR TITLE
fix(Decompiler): Handle multiple large numbers in lobby map settings

### DIFF
--- a/Deltinteger/Deltinteger/Decompiler/TextToElement/TextToElement.cs
+++ b/Deltinteger/Deltinteger/Decompiler/TextToElement/TextToElement.cs
@@ -1200,8 +1200,8 @@ namespace Deltin.Deltinteger.Decompiler.TextToElement
                                     // Add the map.
                                     maps.Add(map.Name);
 
-                                    // Attempt to match an integer at the end (since OW2 introduced numbers at the end of map names)
-                                    Integer(out int _unused);
+                                    // Attempt to consume any number of numbers at the end (since OW2 introduced numbers at the end of map names)
+                                    while (Double(out double _unused)) {};
 
                                     // Indicate that a map was matched in this iteration.
                                     matched = true;


### PR DESCRIPTION
With the Season 4 update, lobby settings can now include multiple large numbers at the end of map names, such as the following:

```
settings
{
	modes
	{
		Skirmish
		{
			enabled maps
			{
				Blizzard World 972777519512068154 972777519512068194
			}
		}
	}
}
```

This PR updates the decompiler to support this new change.
