### PR TITLE
Update Player Hero Stat to allow for Hero array

### DIFF
--- a/Deltinteger/Deltinteger/Elements.json
+++ b/Deltinteger/Deltinteger/Elements.json
@@ -3046,7 +3046,7 @@
           "type": "player"
         },
         "Hero": {
-          "type": "hero"
+          "type": "hero | hero[]"
         },
         "Stat": {
           "type": "PlayerHeroStat"


### PR DESCRIPTION
The Player Hero Stat rule allows for an array of heroes to get the stats from. Also i forgot to change the target branch. I do not know what is currently maintained