### PR TITLE
fix: reconnect VSCode extension commands

### DIFF
--- a/Deltinteger/Deltinteger/.vscode/launch.json
+++ b/Deltinteger/Deltinteger/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/bin/Debug/net6.0/Deltinteger.dll",
+            "program": "${workspaceFolder}/bin/Debug/net8.0/Deltinteger.dll",
             "args": [],
             "cwd": "${workspaceFolder}",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
@@ -21,6 +21,39 @@
             "name": ".NET Core Attach",
             "type": "coreclr",
             "request": "attach"
-        }
+        },
+        {
+            "name": "Debug Script",
+            "type":"coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/bin/Debug/net8.0/Deltinteger.dll",
+            "args":["${file}"],
+            "console": "externalTerminal",
+            "stopAtEntry": true,
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "name": "Debug Decompile",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/bin/Debug/net8.0/Deltinteger.dll",
+            "args":["--decompile-clipboard", "..\\..\\..\\ostwSandbox\\decompilerDebug.ostw"],
+            "console": "integratedTerminal",
+            "stopAtEntry": false,
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "name": "Setting schema",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/bin/Debug/net8.0/Deltinteger.dll",
+            "args":["--schema"],
+            "console": "integratedTerminal",
+            "stopAtEntry": false,
+            "internalConsoleOptions": "openOnSessionStart"
+        },
     ]
 }

--- a/Deltinteger/Deltinteger/Program.cs
+++ b/Deltinteger/Deltinteger/Program.cs
@@ -17,7 +17,7 @@ namespace Deltin.Deltinteger
 {
     public class Program
     {
-        public const string VERSION = "v2.8.5";
+        public const string VERSION = "v2.8.7";
 
         public static readonly string ExeFolder = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
 

--- a/Deltinteger/Deltinteger/publish.ps1
+++ b/Deltinteger/Deltinteger/publish.ps1
@@ -1,6 +1,6 @@
 $configuration = 'Release'
 $framework = 'net8.0'
-$ostw_version = 'v2.8.5'
+$ostw_version = 'v2.8.7'
 
 # Cross platform, no runtime included.
 '* Publishing self-contained'


### PR DESCRIPTION
This PR adds back the command listeners in the langserver which the VSCode extension relies on to decompile from clipboard

__Changelog__:
- fix: reconnect decompile commands
- chore: Update launch.json
- build: bump langserver version number
