### PR TITLE
decompiler fix

### DIFF
--- a/Deltinteger/Deltinteger/Decompiler/TextToElement/EventInfo.cs
+++ b/Deltinteger/Deltinteger/Decompiler/TextToElement/EventInfo.cs
@@ -39,7 +39,7 @@ namespace Deltin.Deltinteger.Decompiler.TextToElement
             ("Brigitte", PlayerSelector.Brigitte),
             ("Cassidy", PlayerSelector.Cassidy),
             ("Doomfist", PlayerSelector.Doomfist),
-            ("D.va", PlayerSelector.Dva),
+            ("D.Va", PlayerSelector.Dva),
             ("Echo", PlayerSelector.Echo),
             ("Genji", PlayerSelector.Genji),
             ("Hanzo", PlayerSelector.Hanzo),

--- a/Deltinteger/Deltinteger/Elements.json
+++ b/Deltinteger/Deltinteger/Elements.json
@@ -6627,7 +6627,7 @@
           "alias": "Lucio"
         },
         {
-          "name": "D.va",
+          "name": "D.Va",
           "alias": "Dva"
         },
         "Mei",
@@ -6659,7 +6659,7 @@
       "Brigitte",
       "Cassidy",
       {
-        "name": "D.va",
+        "name": "D.Va",
         "alias": "Dva"
       },
       "Doomfist",

--- a/Deltinteger/Deltinteger/Elements.json
+++ b/Deltinteger/Deltinteger/Elements.json
@@ -601,7 +601,7 @@
       "parameters": {
         "Center": {
           "documentation": "The position to which to measure proximity. Can use most Value Syntax related to reporting a position in the map.",
-          "type": "vector",
+          "type": "player | vector",
           "defaultValue": "Vector"
         },
         "Team": {
@@ -795,7 +795,7 @@
         },
         "Position": {
           "documentation": "The position in the world in where the angle ends.",
-          "type": "vector",
+          "type": "player | vector",
           "defaultValue": "Vector"
         }
       }
@@ -1806,7 +1806,7 @@
       "parameters": {
         "Center": {
           "documentation": "The center position from which to measure distance. Can use most Vector based Value Syntax to provide this value.",
-          "type": "vector",
+          "type": "player | vector",
           "defaultValue": "Vector"
         },
         "Radius": {
@@ -3417,7 +3417,7 @@
         },
         "Color": {
           "documentation": "The color of the beam effect to be created. IF a particular team is chosen, the effect will either be red or blue, depending on whether the team is hostile to the viewer. Does not apply to sound effects.",
-          "type": "color",
+          "type": "color | team",
           "defaultValue": "Color"
         },
         "Reevaluation": {
@@ -3476,7 +3476,7 @@
         },
         "Color": {
           "documentation": "The color of the effect to be created. IF a particular team is chosen, the effect will either be red or blue, depending on whether the team is hostile to the viewer. Does not apply to sound effects.",
-          "type": "color",
+          "type": "color | team",
           "defaultValue": "Color"
         },
         "Position": {
@@ -4434,7 +4434,7 @@
         },
         "Color": {
           "documentation": "The color of the effect to be created. IF a particular team is chosen, the effect will either be red or blue, depending on whether the team is hostile to the viewer.",
-          "type": "color",
+          "type": "color | team",
           "defaultValue": "Color"
         },
         "Position": {
@@ -5729,7 +5729,7 @@
           "defaultValue": "Event Player"
         },
         "Position": {
-          "type": "vector",
+          "type": "player | vector",
           "defaultValue": "Vector"
         },
         "Reevaluation": {

--- a/Deltinteger/Deltinteger/Elements/ITypeSupplier.cs
+++ b/Deltinteger/Deltinteger/Elements/ITypeSupplier.cs
@@ -27,6 +27,8 @@ static class ElementJsonTypeHelper
         "team" => typeSupplier.Team(),
         "gamemode" => typeSupplier.GameMode(),
         "color" => typeSupplier.Color(),
+        "color | team" or
+        "team | color" => typeSupplier.ColorOrTeam(),
         "hero[]" => typeSupplier.Array(typeSupplier.Hero()),
         "string[]" => typeSupplier.Array(typeSupplier.String()),
         "hero | hero[]" => typeSupplier.PipeType(typeSupplier.Hero(), typeSupplier.Array(typeSupplier.Hero())),
@@ -56,6 +58,7 @@ public interface IElementsJsonTypeSupplier<T>
     T Map();
     T GameMode();
     T Team();
+    T ColorOrTeam();
     T Array(T innerType);
     T PipeType(T a, T b);
 }

--- a/Deltinteger/Deltinteger/Lobby/Heroes.cs
+++ b/Deltinteger/Deltinteger/Lobby/Heroes.cs
@@ -198,7 +198,7 @@ namespace Deltin.Deltinteger.Lobby
                 new HeroSettingCollection("Bastion").AddUlt("Configuration: Artillery", true).AddProjectile(true).AddAbility("Reconfigure").AddAbility("A-36 Tactical Grenade", hasKnockback: true),
                 new HeroSettingCollection("Brigitte").AddUlt("Rally", true).AddHealer().AddAbility("Barrier Shield", rechargeable: true).AddAbility("Repair Pack").AddAbility("Shield Bash", hasKnockback: true).AddAbility("Whip Shot", hasKnockback: true).RemoveAmmunition(),
                 new HeroSettingCollection("Cassidy").AddUlt("Deadeye").AddSecondaryFire().AddAbility("Combat Roll").AddAbility("Magnetic Grenade").AddProjectile(true),
-                new HeroSettingCollection("D.va").AddUlt("Self-Destruct", true).AddRange("Self Destruct Knockback Scalar", 0, 200).AddAbility("Micro Missiles").AddAbility("Boosters", hasKnockback: true).AddAbility("Defense Matrix", hasCooldown: false, rechargeable: true).AddRange("Call Mech Knockback Scalar", 0, 400).AddSwitch("Spawn Without Mech", false).RemoveAmmunition(),
+                new HeroSettingCollection("D.Va").AddUlt("Self-Destruct", true).AddRange("Self Destruct Knockback Scalar", 0, 200).AddAbility("Micro Missiles").AddAbility("Boosters", hasKnockback: true).AddAbility("Defense Matrix", hasCooldown: false, rechargeable: true).AddRange("Call Mech Knockback Scalar", 0, 400).AddSwitch("Spawn Without Mech", false).RemoveAmmunition(),
                 new HeroSettingCollection("Doomfist")
                     .AddUlt("Meteor Strike", hasKnockback: true, hasDuration: true)
                     .AddProjectile(false).AddRange("Ammunition Regeneration Time Scalar", 33, 500)

--- a/Deltinteger/Deltinteger/LobbySettings.json
+++ b/Deltinteger/Deltinteger/LobbySettings.json
@@ -162,7 +162,7 @@
                     ]
                 },
                 {
-                    "name": "D.va",
+                    "name": "D.Va",
                     "template": "base_hero",
                     "$ult": "Self-Destruct",
                     "$ult_duration": true,

--- a/Deltinteger/Deltinteger/Maps.json
+++ b/Deltinteger/Deltinteger/Maps.json
@@ -427,6 +427,8 @@
   {
     "Name": "Rialto",
     "GameModes": [
+      "Escort",
+      "Skirmish",
       "Retribution"
     ]
   },

--- a/Deltinteger/Deltinteger/Parse/ScriptTypes.cs
+++ b/Deltinteger/Deltinteger/Parse/ScriptTypes.cs
@@ -91,6 +91,7 @@ namespace Deltin.Deltinteger.Parse
         public CodeType Map() => EnumType("Map");
         public CodeType GameMode() => EnumType("GameMode");
         public CodeType Team() => EnumType("Team");
+        public CodeType ColorOrTeam() => new PipeType(Color(), Team());
         public CodeType Array(CodeType innerType) => new ArrayType(this, innerType);
         public CodeType PipeType(CodeType a, CodeType b) => new PipeType(a, b);
     }

--- a/Deltinteger/Deltinteger/Parse/Vanilla/StaticAnalysisData.cs
+++ b/Deltinteger/Deltinteger/Parse/Vanilla/StaticAnalysisData.cs
@@ -65,6 +65,7 @@ class VanillaTypeData : IElementsJsonTypeSupplier<VanillaType>
     public VanillaType Map() => MapType;
     public VanillaType GameMode() => GameModeType;
     public VanillaType Team() => TeamType;
+    public VanillaType ColorOrTeam() => PipeType(Color(), Team());
     public VanillaType Array(VanillaType innerType)
     {
         lock (locker)


### PR DESCRIPTION
This PR fixes a few bugs with the "3.0" decompiler:
- Rialto not being accepted as a valid map
- D.Va not being decompiled correctly

In addition, this PR loosens the typing on common functions to accept common substitutes (allowing a player entity to cast to the position of the player) or slightly unexpected correct behavior (allowing a Team as the "color" of an effect) 
