### PR TITLE
fix: colosseo typo

### DIFF
--- a/Deltinteger/Deltinteger/Maps.json
+++ b/Deltinteger/Deltinteger/Maps.json
@@ -654,7 +654,7 @@
     ]
   },
   {
-    "Name": "Colloseo",
+    "Name": "Colosseo",
     "GameModes": [
       "Push",
       "Skirmish"

--- a/overwatch-script-to-workshop/json-schemas/LobbySettingValidation.json
+++ b/overwatch-script-to-workshop/json-schemas/LobbySettingValidation.json
@@ -402,7 +402,7 @@
       "items": {
         "type": "string",
         "enum": [
-          "Colloseo",
+          "Colosseo",
           "New Queen Street",
           "Esperança",
           "Runasapi"
@@ -783,7 +783,7 @@
           "Circuit Royal",
           "Midtown",
           "Paraíso",
-          "Colloseo",
+          "Colosseo",
           "New Queen Street",
           "Esperança",
           "Shambali Monastery",


### PR DESCRIPTION
This PR fixes the map Colosseo being incorrectly spelled as "Colloseo"
