### PR TITLE
Extra element info in output + MinWait() decompile bug fixed

### DIFF
--- a/Deltinteger/Deltinteger/Decompiler/ElementToCode/FunctionConvert.cs
+++ b/Deltinteger/Deltinteger/Decompiler/ElementToCode/FunctionConvert.cs
@@ -284,17 +284,13 @@ namespace Deltin.Deltinteger.Decompiler.ElementToCode
                 }).OnInterupt(() => Cap(decompiler, withBlock)).Get();
             }},
             {"Wait", (decompiler, function) => {
-                // Convert the Wait to a MinWait if the wait duration is less than or equal to the minimum.
-                if ((function.Values[0] is NumberExpression number && number.Value <= Constants.MINIMUM_WAIT) || (function.Values[0] is FunctionExpression durationFunc && durationFunc.Function.Name == "False"))
+                // Convert the Wait to a MinWait if the wait duration is less than or equal to the minimum and the behavior is set to Ignore Condition.
+                if (function.Values[1] is ConstantEnumeratorExpression enumerator &&
+                    enumerator.Member == ElementRoot.Instance.GetEnumValueFromWorkshop("WaitBehavior", "Ignore Condition") &&
+                    ((function.Values[0] is NumberExpression number && number.Value <= Constants.MINIMUM_WAIT) ||
+     (function.Values[0] is FunctionExpression durationFunc && durationFunc.Function.Name == "False")))
                 {
-                    decompiler.Append("MinWait(");
-
-                    // Add wait behavior if it is not the default.
-                    if (function.Values[1] is ConstantEnumeratorExpression enumerator && enumerator.Member != ElementRoot.Instance.GetEnumValueFromWorkshop("WaitBehavior", "Ignore Condition"))
-                        enumerator.Decompile(decompiler);
-                    
-                    // End function
-                    decompiler.Append(")");
+                    decompiler.Append("MinWait()");
 
                     // Finished
                     decompiler.EndAction();

--- a/Deltinteger/Deltinteger/Elements/Rule.cs
+++ b/Deltinteger/Deltinteger/Elements/Rule.cs
@@ -63,7 +63,7 @@ namespace Deltin.Deltinteger.Elements
                 .AppendKeywordLine("event")
                 .AppendLine("{")
                 .Indent();
-            
+
             ElementRoot.Instance.GetEnumValue("Event", RuleEvent.ToString()).ToWorkshop(builder, ToWorkshopContext.Other);
             builder.Append(";").AppendLine();
 
@@ -125,7 +125,7 @@ namespace Deltin.Deltinteger.Elements
 
                 foreach (var action in Actions)
                     action.ToWorkshop(builder, ToWorkshopContext.Action);
-                
+
                 builder.SetCurrentIndent(resetIndentInCaseOfUnbalance);
                 builder.Outdent().AppendLine("}");
             }

--- a/Deltinteger/Deltinteger/Elements/Rule.cs
+++ b/Deltinteger/Deltinteger/Elements/Rule.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Linq;
+
 namespace Deltin.Deltinteger.Elements
 {
     public class Rule
@@ -43,6 +46,11 @@ namespace Deltin.Deltinteger.Elements
 
         public void ToWorkshop(WorkshopBuilder builder)
         {
+            
+            // Element count comment.
+            if (builder.IncludeComments)
+                builder.AppendLine("// Rule Element Count: " + ElementCount());
+
             if (Disabled)
             {
                 builder.AppendKeyword("disabled")
@@ -51,12 +59,11 @@ namespace Deltin.Deltinteger.Elements
             builder.AppendKeyword("rule")
                 .AppendLine("(\"" + Name + "\")")
                 .AppendLine("{")
-                .AppendLine()
                 .Indent()
                 .AppendKeywordLine("event")
                 .AppendLine("{")
                 .Indent();
-
+            
             ElementRoot.Instance.GetEnumValue("Event", RuleEvent.ToString()).ToWorkshop(builder, ToWorkshopContext.Other);
             builder.Append(";").AppendLine();
 
@@ -78,10 +85,13 @@ namespace Deltin.Deltinteger.Elements
             builder.Outdent()
                 .AppendLine("}");
 
-            if (Conditions?.Length > 0)
-            {
-                builder.AppendLine()
-                    .AppendKeywordLine("conditions")
+            if (Conditions?.Length > 0) {
+                builder.AppendLine();
+                    
+                if (builder.IncludeComments)
+                    builder.AppendLine("// Element Count: " + Conditions.Sum(x => x.ElementCount()) + ", Condition Count: " + Conditions.Length);
+                
+                builder.AppendKeywordLine("conditions")
                     .AppendLine("{")
                     .Indent();
 
@@ -96,16 +106,26 @@ namespace Deltin.Deltinteger.Elements
             {
                 builder.AppendLine();
 
-                // Action count comment.
+                // Action and element count comment.
                 if (builder.IncludeComments)
-                    builder.AppendLine("// Action count: " + Actions.Length);
+                {
+                    int largestCount = Actions.Max(x => x.ElementCount());
+                    Element largestAction = Array.FindIndex(Actions, x => x.ElementCount() == largestCount);
+                    int totalElementCount = Actions.Sum(x => x.ElementCount());
 
+                    builder.AppendLine($"// Element Count: {totalElementCount}, Action Count: {Actions.Length}");
+                    if (Actions.Length > 1) {
+                        builder.AppendLine($"// Largest Action Index: {largestAction} using {largestCount} Elements");
+                    }
+                       
+                }
+                
                 builder.AppendKeywordLine("actions").AppendLine("{").Indent();
                 int resetIndentInCaseOfUnbalance = builder.GetCurrentIndent();
 
                 foreach (var action in Actions)
                     action.ToWorkshop(builder, ToWorkshopContext.Action);
-
+                
                 builder.SetCurrentIndent(resetIndentInCaseOfUnbalance);
                 builder.Outdent().AppendLine("}");
             }


### PR DESCRIPTION
Some extra element info added to the output .ow script that I think could be useful for debugging and optimizing later on.
Also issue #316 should now be fixed!

![image](https://github.com/user-attachments/assets/292d718f-5c18-4fa7-83ae-4fe27bfd1977)
