### PR TITLE
fix: null-guard VariableOption.CanBeSetReference() to prevent NullReferenceException

### DIFF
--- a/Deltinteger/Deltinteger/Parse/ExpressionTree.cs
+++ b/Deltinteger/Deltinteger/Parse/ExpressionTree.cs
@@ -591,7 +591,7 @@ namespace Deltin.Deltinteger.Parse
             }
 
             public bool CanBeSetDirectly() => _variable.Attributes.CanBeSet;
-            public bool CanBeSetReference() => _variable.CodeType.GetCodeType(_parseInfo.TranslateInfo).AsReferenceResetSettability;
+            public bool CanBeSetReference() => _variable.CodeType.GetCodeType(_parseInfo.TranslateInfo)?.AsReferenceResetSettability ?? true;
         }
     }
 


### PR DESCRIPTION
## Summary

`VariableOption.CanBeSetReference()` in `ExpressionTree.cs` called `.AsReferenceResetSettability` directly on the result of `GetCodeType()`, which returns null when the `ICodeTypeSolver` for a Player-typed variable hasn't been fully resolved.

This caused a hard `NullReferenceException` crash during parsing whenever any dotted player-variable write appeared in a script — e.g. `EventPlayer.Currency -= 10` — making player variable assignments entirely unusable.

## What changed

**`Deltinteger/Deltinteger/Parse/ExpressionTree.cs` line 594** — one-character fix adding null-conditional access:

```csharp
// Before (crashes when GetCodeType() returns null):
public bool CanBeSetReference() =>
    _variable.CodeType.GetCodeType(_parseInfo.TranslateInfo).AsReferenceResetSettability;

// After (null-safe):
public bool CanBeSetReference() =>
    _variable.CodeType.GetCodeType(_parseInfo.TranslateInfo)?.AsReferenceResetSettability ?? true;
```

## Why `?? true` is the correct fallback

`PlayerType` already sets `AsReferenceResetSettability = true` (see `PlayerType.cs` line 74). The `ExpressionPart.CanBeSetReference()` overload on line 315 already uses this exact same null-safe pattern:

```csharp
public bool CanBeSetReference() => _expression.Type()?.AsReferenceResetSettability ?? true;
```

This fix makes `VariableOption` consistent with `ExpressionPart`. Returning `true` as the fallback is correct: it means "yes, this can be set by reference", which is the intended behavior for Player-typed variables.

## Reproduction

Any `.del` file with a dotted player-variable assignment, in either a rule body or a function body:

```del
playervar Number Currency;

rule: "Test"
Event.OngoingEachPlayer
{
    EventPlayer.Currency = 100;  // NullReferenceException without this fix
}
```
